### PR TITLE
Add Kubernetes manifests, CI and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+LICENSE
+README.md
+tests/

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,36 @@
+name: Build and push container image
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: python-app
+
+jobs:
+  build-push:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run unit tests
+        run: python tests/test.py
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/thejaxon/${{ env.IMAGE_NAME }}
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/python:3.7-alpine
+
+EXPOSE 8000
+
+RUN addgroup -S jaxon && \ 
+    adduser -S jaxon -G jaxon
+
+USER jaxon
+
+WORKDIR app
+
+COPY . .
+
+RUN pip install --no-cache-dir --requirement requirements.txt
+
+ENTRYPOINT ["python", "hello.py"]

--- a/README.md
+++ b/README.md
@@ -100,3 +100,23 @@ Copyright (c) 2024 by the Tradebyte Software GmbH.<br/>
 The names and images for `DevOps-Challenge` are trademarks of the Tradebyte Software GmbH.
 
 We love free software!
+
+---
+
+### Solution
+#### Creating Kubernetes manifests
+```bash
+mkdir -pv /home/vagrant/manifests/{redis,python-app}
+
+# Generate redis deployment
+k create deployment redis --image docker.io/redis:7.4.1-alpine3.20  --replicas 1 -oyaml --dry-run=client > manifests/redis/deployment.yaml
+
+# Generate redis svc
+k expose deploy/redis --port 6379 --dry-run=client -oyaml > manifests/redis/service.yaml
+
+# Generate python deployment
+k create deployment python-app --image ghcr.io/thejaxon/python-app --port 8000 --replicas 3 -oyaml --dry-run=client > manifests/python-app/deployment.yaml
+
+# Generate HPA defintion
+k autoscale deployment python-app --min=3 --max=5 --cpu-percent=60 -oyaml --dry-run=client > manifests/python-app/hpa.yaml
+```

--- a/README.md
+++ b/README.md
@@ -119,4 +119,7 @@ k create deployment python-app --image ghcr.io/thejaxon/python-app --port 8000 -
 
 # Generate HPA defintion
 k autoscale deployment python-app --min=3 --max=5 --cpu-percent=60 -oyaml --dry-run=client > manifests/python-app/hpa.yaml
+
+# Generate kustomization files
+kustomize create --autodetect
 ```

--- a/application.yaml
+++ b/application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: python-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    path: manifests/
+    repoURL: 'https://github.com/theJaxon/DevOps-Challenge'
+    targetRevision: HEAD
+  destination:
+    namespace: default
+    server: 'https://kubernetes.default.svc'

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  repository: "https://github.com/theJaxon/DevOps-Challenge"
+resources:
+- redis/
+- python-app/

--- a/manifests/python-app/deployment.yaml
+++ b/manifests/python-app/deployment.yaml
@@ -2,17 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: python-app
-  labels:
-    app: python-app
 spec:
   replicas: 3
-  selector:
-    matchLabels:
-      app: python-app
   template:
-    metadata:
-      labels:
-        app: python-app
     spec:
       containers:
       - image: ghcr.io/thejaxon/python-app

--- a/manifests/python-app/deployment.yaml
+++ b/manifests/python-app/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: python-app
+  labels:
+    app: python-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: python-app
+  template:
+    metadata:
+      labels:
+        app: python-app
+    spec:
+      containers:
+      - image: ghcr.io/thejaxon/python-app
+        name: python-app
+        ports:
+        - containerPort: 8000
+        env:
+          - name: ENVIRONMENT
+            value: "DEV"
+          - name: HOST
+            value: "localhost"
+          - name: PORT
+            value: "8000"
+          - name: REDIS_HOST
+            value: "redis"
+          - name: REDIS_PORT
+            value: "6379"
+          - name: REDIS_DB
+            value: "0"
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"

--- a/manifests/python-app/hpa.yaml
+++ b/manifests/python-app/hpa.yaml
@@ -1,0 +1,15 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: python-app
+spec:
+  maxReplicas: 5
+  minReplicas: 3
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: python-app
+  targetCPUUtilizationPercentage: 60
+status:
+  currentReplicas: 0
+  desiredReplicas: 0

--- a/manifests/python-app/kustomization.yaml
+++ b/manifests/python-app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: python-app
+resources:
+- deployment.yaml
+- hpa.yaml

--- a/manifests/redis/deployment.yaml
+++ b/manifests/redis/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: docker.io/redis:7.4.1-alpine3.20
+        name: redis

--- a/manifests/redis/deployment.yaml
+++ b/manifests/redis/deployment.yaml
@@ -2,17 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
-  labels:
-    app: redis
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app: redis
   template:
-    metadata:
-      labels:
-        app: redis
     spec:
       containers:
       - image: docker.io/redis:7.4.1-alpine3.20

--- a/manifests/redis/kustomization.yaml
+++ b/manifests/redis/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: redis
+resources:
+- deployment.yaml
+- service.yaml

--- a/manifests/redis/service.yaml
+++ b/manifests/redis/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+  - port: 6379
+    protocol: TCP
+    targetPort: 6379
+

--- a/manifests/redis/service.yaml
+++ b/manifests/redis/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  labels:
-    app: redis
 spec:
-  selector:
-    app: redis
   ports:
   - port: 6379
     protocol: TCP


### PR DESCRIPTION
### Changes

- Add CI steps.
- Add `.dockerignore` to reduce image size.
- Add Dockerfile for the python app.
- Add Kubernetes manifests for python and redis.
- Update `README.md` with commands used to generate kubernetes manifests.

### Running Python application preview
![image](https://github.com/user-attachments/assets/06d2fbe7-db1f-4077-91b6-5e6fbd878a8d)
